### PR TITLE
Fix of the russian symbols

### DIFF
--- a/dbcpy/dbc_file.py
+++ b/dbcpy/dbc_file.py
@@ -32,8 +32,9 @@ class DBCFile():
                             f.write(bytes_util.to_bytes(string_block_size))
                             pos = f.tell()
                             f.seek(string_block_offset + string_block_size)
-                            f.write((string + '\0').encode('utf-8'))
-                            string_block_size += len(string + '\0')
+                            string = string.encode('utf-8') + b'\0'
+                            f.write(string)
+                            string_block_size += len(string)
                             f.seek(pos)
                         else:
                             f.write(bytes_util.to_bytes(0))


### PR DESCRIPTION
Russian language strings lost the end-of-line character when the file was overwritten. This caused all next rows to be shifted and other strange consequences

I was able to fix it for myself and maybe it will fix problems for other localizations